### PR TITLE
Document go get command with GOOS set to avoid issue with unrecognized import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Copy `npiperelay.exe` to a location on your path. WSL 2 will read your path and 
 Once you have Go installed (and your GOPATH configured), you need to download and install the tool. This is a little tricky because we are building the tool for Windows from WSL:
 
 ```bash
-$ go get -d github.com/jstarks/npiperelay
+$ GOOS=windows go get -d github.com/jstarks/npiperelay
 $ GOOS=windows go build -o /mnt/c/Users/<myuser>/go/bin/npiperelay.exe github.com/jstarks/npiperelay
 ```
 


### PR DESCRIPTION
Based on upstream issue 3:

> Executing go get -d github.com/jstarks/npiperelay results in the following:
> 
> package golang.org/x/sys/windows: unrecognized import path "golang.org/x/sys/windows" (https fetch: Get https://golang.org/x/sys/windows?go-get=1: dial tcp: i/o timeout)

> I had to do this:
> 
> GOOS=windows go get -d github.com/jstarks/npiperelay
> GOOS=windows go build -o /mnt/c/Users/<username>/go/bin/npiperelay.exe github.com/jstarks/npiperelay