### PR TITLE
Add file properties and version info

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,13 @@
+before:
+  hooks:
+    - 'go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest'
+    - 'goversioninfo
+      -platform-specific
+      -ver-major="{{ .Major }}" -product-ver-major="{{ .Major }}"
+      -ver-minor="{{ .Minor }}" -product-ver-minor="{{ .Minor }}"
+      -ver-patch="{{ .Patch }}" -product-ver-patch="{{ .Patch }}"
+      -file-version="{{ .Version }}+{{ .FullCommit }}" -product-version="{{ .Version }}+{{ .FullCommit }}"'
+
 builds:
 - binary: npiperelay
   goos:

--- a/npiperelay.go
+++ b/npiperelay.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"os"
+	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -21,6 +23,11 @@ var (
 	closeOnEOF      = flag.Bool("ep", false, "terminate on EOF reading from the pipe, even if there is more data to write")
 	closeOnStdinEOF = flag.Bool("ei", false, "terminate on EOF reading from stdin, even if there is more data to write")
 	verbose         = flag.Bool("v", false, "verbose output on stderr")
+
+	version = "0.0.0-dev" // Replaced with value from ldflag in build by GoReleaser: Current Git tag with the v prefix stripped
+	commit  = "unknown"   // Replaced with value from ldflag in build by GoReleaser: Current git commit SHA
+	date    = "unknown"   // Replaced with value from ldflag in build by GoReleaser: Date according RFC3339
+	builtBy = "unknown"   // Replaced with value from ldflag in build by GoReleaser
 )
 
 func dialPipe(p string, poll bool) (*overlappedFile, error) {
@@ -53,6 +60,16 @@ func underlyingError(err error) error {
 }
 
 func main() {
+	flag.Usage = func() {
+		// Custom usage message (default documented here: https://pkg.go.dev/flag#pkg-variables)
+		fmt.Fprintf(flag.CommandLine.Output(), "npiperelay v%s\n", version)
+		fmt.Fprintf(flag.CommandLine.Output(), "  commit %s\n", commit)
+		fmt.Fprintf(flag.CommandLine.Output(), "  build date %s\n", date)
+		fmt.Fprintf(flag.CommandLine.Output(), "  built by %s\n", builtBy)
+		fmt.Fprintf(flag.CommandLine.Output(), "  built with %s\n", runtime.Version())
+		fmt.Fprint(flag.CommandLine.Output(), "\nusage:\n")
+		flag.PrintDefaults()
+	}
 	flag.Parse()
 	args := flag.Args()
 	if len(args) != 1 {

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -1,0 +1,42 @@
+{
+    "FixedFileInfo": {
+        "FileVersion": {
+            "Major": 0,
+            "Minor": 0,
+            "Patch": 0,
+            "Build": 0
+        },
+        "ProductVersion": {
+            "Major": 0,
+            "Minor": 0,
+            "Patch": 0,
+            "Build": 0
+        },
+        "FileFlagsMask": "3f",
+        "FileFlags ": "00",
+        "FileOS": "040004",
+        "FileType": "01",
+        "FileSubType": "00"
+    },
+    "StringFileInfo": {
+        "Comments": "",
+        "CompanyName": "https://github.com/jstarks/npiperelay",
+        "FileDescription": "Access Windows named pipes from WSL",
+        "FileVersion": "0.0.0-dev",
+        "InternalName": "npiperelay",
+        "LegalCopyright": "The npiperelay authors. Licensed under MIT.",
+        "LegalTrademarks": "",
+        "OriginalFilename": "npiperelay.exe",
+        "PrivateBuild": "",
+        "ProductName": "npiperelay",
+        "ProductVersion": "0.0.0-dev",
+        "SpecialBuild": ""
+    },
+    "VarFileInfo": {
+        "Translation": {
+            "LangID": "0409",
+            "CharsetID": "04B0"
+        }
+    },
+    "IconPath": ""
+}


### PR DESCRIPTION
Windows File Properties / Version Info:
- GoReleaser installs GoVersionInfo and executes it before the actual build. GoVersionInfo creates a syso file which contains Microsoft Windows Version Information. When GoReleaser then does the actual build (i.e. executing "go build"), Go will embed the version information in the executable.
- Basic information is set in dedicated file versioninfo.json, and then overridden with goversioninfo command-line arguments when executed from GoReleaser, using GoReleaser template fields.

Help/usage text:
- Some basic version related information are printed in the help/usage text.