### PR TITLE
port vmserial-connect to powershell

### DIFF
--- a/scripts/vmserial-connect.ps1
+++ b/scripts/vmserial-connect.ps1
@@ -1,0 +1,5 @@
+$name=$args[0]
+$comport=$args[1]
+$vmcomport=Get-VMComPort -VMName "$name" -Number "$comport"
+$pipe=$vmcomport.Path -replace "\\","/"
+socat "EXEC:'$((get-command npiperelay).source -replace "\\","/") -ei $pipe',pty,rawer" "STDIO,escape=0xf,rawer"


### PR DESCRIPTION
in case you want to enter the serial console on a Hyper-V server _without_ WSL

still requires `socat`, obviously, but installing it on Windows is a little more complicated than using your package manager. I've tested with the one from [unix-utils](https://sourceforge.net/projects/unix-utils/files/socat/1.7.3.2/) and it works great, but if I use the `socat` from msys2 my terminal sends extra return characters and I'm not sure why.

I would prefer an easier way to put socat in, perhaps a statically-compiled one (or a wild enough wish could even be just to implement the fancy PTY stuff necessary in npiperelay itself?)