### PR TITLE
Bump goreleaser configuration to v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - 'go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest'


### PR DESCRIPTION
This removes the following warning:

    Warning: You are using 'latest' as default version. Will lock to '~> v2'.
    
This is a follow up of:
- https://github.com/albertony/npiperelay/pull/41